### PR TITLE
added search bar, only can search by title for now

### DIFF
--- a/snippets/templates/snippets/list_snippets.html
+++ b/snippets/templates/snippets/list_snippets.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
 
 {% block content %}
-
+<section class="">
+    <form action="{% url 'search_snippet' %}" method="GET">
+        <input type="text" name="q">
+        <button type="submit" class="">Search by title</button>
+      </form>
+  </section>
 {% for snippet in snippets %}
 <article>
   <div class=card>
@@ -14,6 +19,8 @@
     <p>Description: {{ snippet.description }}</p>
   </div>
 </article>
+{% empty %}
+    <h2>Sorry, no results came back.</h2>
 {% endfor %}
 
 <section class="">

--- a/snippets/urls.py
+++ b/snippets/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path("snippets/new", views.add_snippet, name="add_snippet"),
     path("snippets/<int:pk>/edit", views.edit_snippet, name="edit_snippet"),
     path("snippet/<int:pk>/delete", views.delete_snippet, name="delete_snippet"),
+    path("search", views.search_by_title, name="search_snippet"),
 ]

--- a/snippets/views.py
+++ b/snippets/views.py
@@ -64,3 +64,8 @@ def delete_snippet(request, pk):
 
     return render(request, "snippets/delete_snippet.html", {"snippet": snippet})
 
+def search_by_title(request):
+    query = request.GET.get("q")
+    results = Snippet.objects.filter(title__icontains=query)
+
+    return render(request, "snippets/list_snippets.html", {"snippets": results})


### PR DESCRIPTION
The user can now search for a snippet based on the title. No other categories can be searched right now. It will return the. text "Sorry, no results came back." if the search doesn't match any of the titles.